### PR TITLE
Add voting and comment deletion features

### DIFF
--- a/app/controllers/blog_posts_controller.rb
+++ b/app/controllers/blog_posts_controller.rb
@@ -1,6 +1,6 @@
 class BlogPostsController < ApplicationController
-  before_action :authenticate_user!, only: [:index, :edit, :update, :destroy]
-  before_action :load_blog_post, only: [:edit, :update, :show, :destroy]
+  before_action :authenticate_user!, only: [:index, :edit, :update, :destroy, :like, :dislike]
+  before_action :load_blog_post, only: [:edit, :update, :show, :destroy, :like, :dislike]
   before_action :authorize_user!, only: [:edit, :update, :destroy]
 
   def dashboard
@@ -44,6 +44,32 @@ class BlogPostsController < ApplicationController
   def destroy
     @blog_post.destroy
     redirect_to blog_posts_path, notice: "Blog post was successfully deleted."
+  end
+
+  def like
+    vote = @blog_post.votes.find_by(user: current_user)
+    if vote&.value == 1
+      vote.destroy
+    else
+      vote&.update(value: 1) || @blog_post.votes.create(user: current_user, value: 1)
+    end
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.replace(view_context.dom_id(@blog_post, :votes), partial: "blog_posts/vote_buttons", locals: { blog_post: @blog_post }) }
+      format.html { redirect_to @blog_post }
+    end
+  end
+
+  def dislike
+    vote = @blog_post.votes.find_by(user: current_user)
+    if vote&.value == -1
+      vote.destroy
+    else
+      vote&.update(value: -1) || @blog_post.votes.create(user: current_user, value: -1)
+    end
+    respond_to do |format|
+      format.turbo_stream { render turbo_stream: turbo_stream.replace(view_context.dom_id(@blog_post, :votes), partial: "blog_posts/vote_buttons", locals: { blog_post: @blog_post }) }
+      format.html { redirect_to @blog_post }
+    end
   end
 
   private

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -1,5 +1,7 @@
 class CommentsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_comment, only: [:destroy]
+  before_action :authorize_comment!, only: [:destroy]
 
   def create
     @comment = current_user.comments.build(comment_params)
@@ -10,9 +12,25 @@ class CommentsController < ApplicationController
     end
   end
 
+  def destroy
+    blog_post = @comment.blog_post
+    @comment.destroy
+    redirect_to blog_post
+  end
+
   private
 
   def comment_params
     params.require(:comment).permit(:body, :blog_post_id, :parent_id)
+  end
+
+  def set_comment
+    @comment = Comment.find(params[:id])
+  end
+
+  def authorize_comment!
+    unless current_user == @comment.user || current_user == @comment.blog_post.user
+      redirect_to @comment.blog_post, alert: "You are not authorized to perform this action."
+    end
   end
 end

--- a/app/models/blog_post.rb
+++ b/app/models/blog_post.rb
@@ -1,6 +1,7 @@
 class BlogPost < ApplicationRecord
   belongs_to :user
   has_many :comments, dependent: :destroy
+  has_many :votes, dependent: :destroy
   has_one_attached :video
 
   validates :title, presence: true
@@ -18,7 +19,15 @@ class BlogPost < ApplicationRecord
 		published_at? && published_at <= Time.current
 	end
 
-	def schedule?
-		published_at? && published_at > Time.current
-	end
+  def schedule?
+    published_at? && published_at > Time.current
+  end
+
+  def likes_count
+    votes.where(value: 1).count
+  end
+
+  def dislikes_count
+    votes.where(value: -1).count
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   has_many :blog_posts, dependent: :destroy
   has_many :comments, dependent: :destroy
+  has_many :votes, dependent: :destroy
   
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,7 @@
+class Vote < ApplicationRecord
+  belongs_to :user
+  belongs_to :blog_post
+
+  validates :value, inclusion: { in: [-1, 1] }
+  validates :user_id, uniqueness: { scope: :blog_post_id }
+end

--- a/app/views/blog_posts/_vote_buttons.html.erb
+++ b/app/views/blog_posts/_vote_buttons.html.erb
@@ -1,0 +1,8 @@
+<div class="flex items-center space-x-4">
+  <%= button_to like_blog_post_path(blog_post), method: :post, form: { data: { turbo_stream: true } }, class: "text-blue-600" do %>
+    Like (<%= blog_post.likes_count %>)
+  <% end %>
+  <%= button_to dislike_blog_post_path(blog_post), method: :post, form: { data: { turbo_stream: true } }, class: "text-red-600" do %>
+    Dislike (<%= blog_post.dislikes_count %>)
+  <% end %>
+</div>

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -25,6 +25,10 @@
     </div>
     <p class="text-sm text-gray-500">Author: <%= @blog_post.user.username %></p>
 
+    <%= turbo_frame_tag dom_id(@blog_post, :votes) do %>
+      <%= render 'blog_posts/vote_buttons', blog_post: @blog_post %>
+    <% end %>
+
     <% if user_signed_in? %>
       <div class="mt-6">
         <%= render 'comments/form', blog_post: @blog_post, parent: nil %>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -6,6 +6,9 @@
     <div data-reply-form-target="form" class="hidden ml-4">
       <%= render 'comments/form', blog_post: comment.blog_post, parent: comment %>
     </div>
+    <% if current_user == comment.user || current_user == comment.blog_post.user %>
+      <%= button_to 'Delete', comment_path(comment), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class: 'text-sm text-red-600 mt-1' %>
+    <% end %>
   <% end %>
   <div class="ml-4 space-y-4">
     <% comment.replies.each do |reply| %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,11 @@ Rails.application.routes.draw do
       get :dashboard
       get :index
     end
+    member do
+      post :like
+      post :dislike
+    end
   end
-  resources :comments, only: [:create]
+  resources :comments, only: [:create, :destroy]
   root "blog_posts#dashboard"
 end

--- a/db/migrate/20250704130534_create_votes.rb
+++ b/db/migrate/20250704130534_create_votes.rb
@@ -1,0 +1,12 @@
+class CreateVotes < ActiveRecord::Migration[7.1]
+  def change
+    create_table :votes do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :blog_post, null: false, foreign_key: true
+      t.integer :value, null: false
+
+      t.timestamps
+    end
+    add_index :votes, [:user_id, :blog_post_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -88,9 +88,22 @@ ActiveRecord::Schema[7.1].define(version: 2024_04_28_120513) do
     t.index ["username"], name: "index_users_on_username", unique: true
   end
 
+  create_table "votes", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "blog_post_id", null: false
+    t.integer "value", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["blog_post_id"], name: "index_votes_on_blog_post_id"
+    t.index ["user_id", "blog_post_id"], name: "index_votes_on_user_id_and_blog_post_id", unique: true
+    t.index ["user_id"], name: "index_votes_on_user_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blog_posts", "users"
   add_foreign_key "comments", "blog_posts"
   add_foreign_key "comments", "users"
+  add_foreign_key "votes", "users"
+  add_foreign_key "votes", "blog_posts"
 end


### PR DESCRIPTION
## Summary
- model votes and reference users and blog posts
- relate votes to blog posts and users
- expose like/dislike endpoints
- show like and dislike buttons on video page
- allow users to delete their comments
- add migrations and schema for votes

## Testing
- `RBENV_VERSION=3.3.8 bundle exec rails test` *(fails: `bundler: command not found: rails`)*

------
https://chatgpt.com/codex/tasks/task_e_6867d107ff1c8322851fc031434b080c