### PR TITLE
Add translation support

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,6 +11,9 @@ class ApplicationController < ActionController::Base
         end
 
         def set_locale
-                I18n.locale = current_user&.language || I18n.default_locale
+                locale = session[:locale] || current_user&.language || I18n.default_locale
+                locale = I18n.default_locale unless I18n.available_locales.map(&:to_s).include?(locale.to_s)
+                I18n.locale = locale
+                session[:locale] = locale
         end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,11 +1,16 @@
 class ApplicationController < ActionController::Base
-	include Pagy::Backend
-	before_action :configure_permitted_parameters, if: :devise_controller?
+        include Pagy::Backend
+        before_action :set_locale
+        before_action :configure_permitted_parameters, if: :devise_controller?
 
 	protected
 
-	def configure_permitted_parameters
-		devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
-		devise_parameter_sanitizer.permit(:account_update, keys: [:username])
-	end
+        def configure_permitted_parameters
+                devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
+                devise_parameter_sanitizer.permit(:account_update, keys: [:username, :language])
+        end
+
+        def set_locale
+                I18n.locale = current_user&.language || I18n.default_locale
+        end
 end

--- a/app/controllers/languages_controller.rb
+++ b/app/controllers/languages_controller.rb
@@ -1,0 +1,10 @@
+class LanguagesController < ApplicationController
+  def update
+    locale = params[:locale]
+    if I18n.available_locales.map(&:to_s).include?(locale)
+      session[:locale] = locale
+      current_user.update(language: locale) if user_signed_in?
+    end
+    redirect_back fallback_location: root_path
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,8 @@ class User < ApplicationRecord
   has_many :blog_posts, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :votes, dependent: :destroy
+
+  validates :language, inclusion: { in: %w[en zh] }, presence: true
   
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/app/views/blog_posts/_form.html.erb
+++ b/app/views/blog_posts/_form.html.erb
@@ -1,32 +1,32 @@
 <div class="max-w-xl mx-auto mt-6 bg-white rounded-lg shadow p-8 space-y-6">
   <h1 class="text-2xl font-bold text-gray-800 text-center">
-    <%= blog_post.new_record? ? "Upload Your Video" : "Edit Video" %>
+    <%= blog_post.new_record? ? t('posts.upload_your_video') : t('posts.edit_video') %>
   </h1>
 
   <%= form_with model: blog_post, local: true, html: { multipart: true } do |f| %>
     <div class="space-y-4">
       <div>
-        <%= f.label :title, "Title", class: "block mb-1 font-medium text-gray-700" %>
-        <%= f.text_field :title, placeholder: "Enter video title...", class: "w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3" %>
+        <%= f.label :title, t('posts.title'), class: "block mb-1 font-medium text-gray-700" %>
+        <%= f.text_field :title, placeholder: t('posts.enter_title'), class: "w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3" %>
       </div>
 
       <div>
-        <%= f.label :description, "Description", class: "block mb-1 font-medium text-gray-700" %>
-        <%= f.text_area :description, placeholder: "Write a brief description...", rows: 4, class: "w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3" %>
+        <%= f.label :description, t('posts.description'), class: "block mb-1 font-medium text-gray-700" %>
+        <%= f.text_area :description, placeholder: t('posts.enter_description'), rows: 4, class: "w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3" %>
       </div>
 
       <div>
-        <%= f.label :video, "Choose Video", class: "block mb-1 font-medium text-gray-700" %>
+        <%= f.label :video, t('posts.choose_video'), class: "block mb-1 font-medium text-gray-700" %>
         <%= f.file_field :video, accept: "video/*", class: "w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3 bg-white file:bg-blue-500 file:text-white file:rounded file:border-0 file:px-4 file:py-2 hover:file:bg-blue-600" %>
       </div>
 
       <div>
-        <%= f.label :published_at, "Publish At", class: "block mb-1 font-medium text-gray-700" %>
+        <%= f.label :published_at, t('posts.publish_at'), class: "block mb-1 font-medium text-gray-700" %>
         <%= f.datetime_select :published_at, include_blank: true %>
       </div>
 
       <div class="pt-4 text-center">
-        <%= f.submit blog_post.new_record? ? "Upload Video" : "Update Video", class: "bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-6 rounded-xl shadow transition duration-300" %>
+        <%= f.submit blog_post.new_record? ? t('posts.upload_video') : t('posts.update_video'), class: "bg-blue-500 hover:bg-blue-600 text-white font-semibold py-3 px-6 rounded-xl shadow transition duration-300" %>
       </div>
     </div>
   <% end %>

--- a/app/views/blog_posts/edit.html.erb
+++ b/app/views/blog_posts/edit.html.erb
@@ -1,9 +1,9 @@
 <div class="py-5">
-  <h3 class="text-base font-semibold leading-6 text-gray-900">Edit</h3>
+  <h3 class="text-base font-semibold leading-6 text-gray-900"><%= t('posts.edit') %></h3>
 </div>
 
 <%= render 'form', blog_post: @blog_post %>
 
 <div class="flex justify-end m-3">
-  <%= button_to "Delete", @blog_post, method: :delete, data: { turbo_confirm: "Are you sure?" }, class: "inline-flex items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600", remote: true %>
+  <%= button_to t('common.delete'), @blog_post, method: :delete, data: { turbo_confirm: t('common.are_you_sure') }, class: "inline-flex items-center rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600", remote: true %>
 </div>

--- a/app/views/blog_posts/new.html.erb
+++ b/app/views/blog_posts/new.html.erb
@@ -1,5 +1,5 @@
 <div class="py-5">
-  <h3 class="text-base font-semibold leading-6 text-gray-900">New Blog</h3>
+  <h3 class="text-base font-semibold leading-6 text-gray-900"><%= t('posts.new_blog') %></h3>
 </div>
 
 <%= render 'form', blog_post: @blog_post %>

--- a/app/views/blog_posts/show.html.erb
+++ b/app/views/blog_posts/show.html.erb
@@ -19,11 +19,11 @@
 
   <div class="p-6 space-y-4">
     <h1 class="text-2xl font-bold text-gray-800"><%= @blog_post.title %></h1>
-    <p class="text-sm text-gray-500">Uploaded at <%= l(@blog_post.created_at, format: :short) %></p>
+    <p class="text-sm text-gray-500"><%= t('posts.uploaded_at') %> <%= l(@blog_post.created_at, format: :short) %></p>
     <div class="text-gray-700 prose">
       <%= simple_format(@blog_post.description) %>
     </div>
-    <p class="text-sm text-gray-500">Author: <%= @blog_post.user.username %></p>
+    <p class="text-sm text-gray-500"><%= t('posts.author') %>: <%= @blog_post.user.username %></p>
 
     <%= turbo_frame_tag dom_id(@blog_post, :votes) do %>
       <%= render 'blog_posts/vote_buttons', blog_post: @blog_post %>
@@ -34,7 +34,7 @@
         <%= render 'comments/form', blog_post: @blog_post, parent: nil %>
       </div>
     <% else %>
-      <p class="text-sm text-gray-500 mt-6">Please <%= link_to 'sign in', new_user_session_path, class: 'text-blue-600' %> to add a comment.</p>
+      <p class="text-sm text-gray-500 mt-6"><%= t('posts.sign_in_prompt_html', link: link_to(t('nav.login'), new_user_session_path, class: 'text-blue-600')) %></p>
     <% end %>
 
     <div class="mt-8 space-y-4">

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -2,12 +2,12 @@
   <p class="font-semibold text-gray-800"><%= comment.user.username %></p>
   <p class="text-gray-600"><%= simple_format(comment.body) %></p>
   <% if user_signed_in? %>
-    <button data-action="reply-form#toggle" class="text-sm text-blue-600 mt-1">Reply</button>
+    <button data-action="reply-form#toggle" class="text-sm text-blue-600 mt-1"><%= t('comments.reply') %></button>
     <div data-reply-form-target="form" class="hidden ml-4">
       <%= render 'comments/form', blog_post: comment.blog_post, parent: comment %>
     </div>
     <% if current_user == comment.user || current_user == comment.blog_post.user %>
-      <%= button_to 'Delete', comment_path(comment), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class: 'text-sm text-red-600 mt-1' %>
+      <%= button_to t('common.delete'), comment_path(comment), method: :delete, form: { data: { turbo_confirm: t('common.are_you_sure') } }, class: 'text-sm text-red-600 mt-1' %>
     <% end %>
   <% end %>
   <div class="ml-4 space-y-4">

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -5,14 +5,14 @@
   <% end %>
   <div class="my-2">
     <% unless parent %>
-      <%= f.label :body, 'Add a comment', class: 'block text-gray-700 font-medium mb-1' %>
+      <%= f.label :body, t('comments.add'), class: 'block text-gray-700 font-medium mb-1' %>
     <% end %>
-    <%= f.text_area :body, rows: 3, placeholder: 'Write your comment...', class: 'w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3' %>
+    <%= f.text_area :body, rows: 3, placeholder: t('comments.placeholder'), class: 'w-full border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500 p-3' %>
   </div>
   <div class="flex space-x-2">
-    <%= f.submit 'Post Comment', class: 'bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-xl shadow transition duration-300' %>
+    <%= f.submit t('comments.post'), class: 'bg-blue-500 hover:bg-blue-600 text-white font-semibold py-2 px-4 rounded-xl shadow transition duration-300' %>
     <% if parent %>
-      <button type="button" data-action="reply-form#toggle" class="bg-gray-200 px-4 py-2 rounded-xl">Cancel</button>
+      <button type="button" data-action="reply-form#toggle" class="bg-gray-200 px-4 py-2 rounded-xl"><%= t('common.cancel') %></button>
     <% end %>
   </div>
 <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <%= image_tag("logo.png", alt: 'blopo logo', class: "mx-auto h-10 w-auto") %>
-    <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Edit <%= resource_name.to_s.humanize %></h2>
+    <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('devise.registrations.edit.title', model: resource_name.to_s.humanize) %></h2>
   </div>
 
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
@@ -18,6 +18,12 @@
                     required: true,
                     autofocus: true,
                     input_html: { autocomplete: "username", class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" } %>
+
+        <%= f.input :language,
+                    collection: [[t('language.english'), 'en'], [t('language.chinese'), 'zh']],
+                    include_blank: false,
+                    label: t('language.label'),
+                    input_html: { class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" } %>
         <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
           <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
         <% end %>
@@ -32,15 +38,15 @@
         <%= f.input :current_password,
                     required: true,
                     input_html: { autocomplete: "current-password", class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" } %>
-        <%= f.button :submit, "Update", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+        <%= f.button :submit, t('devise.registrations.edit.update'), class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
 
       </div>
     <% end %>
     <div class="flex justify-center">
-      <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "text-sm font-semibold text-red-600 hover:text-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600" %>
+      <%= button_to t('devise.registrations.edit.cancel'), registration_path(resource_name), data: { confirm: t('common.are_you_sure'), turbo_confirm: t('common.are_you_sure') }, method: :delete, class: "text-sm font-semibold text-red-600 hover:text-red-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600" %>
     </div>
     <div class="mt-6 text-center">
-      <%= link_to "Back", :back, class: "text-sm font-semibold text-gray-600 hover:text-gray-500" %>
+      <%= link_to t('common.back'), :back, class: "text-sm font-semibold text-gray-600 hover:text-gray-500" %>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <%= image_tag("logo.png", alt: 'blopo logo', class: "mx-auto h-10 w-auto") %>
-    <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Sign up</h2>
+    <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('devise.registrations.new.signup') %></h2>
   </div>
 
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
@@ -27,14 +27,14 @@
                     required: true,
                     input_html: { autocomplete: "new-password", class: "block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6" } %>
 
-        <%= f.button :submit, "Sign up", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+        <%= f.button :submit, t('devise.registrations.new.signup'), class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
       </div>
     <% end %>
 
     <p class="mt-10 text-center text-sm text-gray-500">
-      Already have an account?
+      <%= t('devise.registrations.new.have_account') %>
        <%= link_to user_session_path do %>
-        <span class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">Login</span>
+        <span class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500"><%= t('devise.registrations.new.login') %></span>
       <% end %>
     </p>
   </div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="flex min-h-full flex-col justify-center px-6 py-12 lg:px-8">
   <div class="sm:mx-auto sm:w-full sm:max-w-sm">
     <%= image_tag("logo.png", alt: 'blopo logo', class: "mx-auto h-10 w-auto") %>
-    <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900">Log in</h2>
+    <h2 class="mt-10 text-center text-2xl font-bold leading-9 tracking-tight text-gray-900"><%= t('devise.sessions.new.login') %></h2>
   </div>
 
   <div class="mt-10 sm:mx-auto sm:w-full sm:max-w-sm">
@@ -26,21 +26,21 @@
         <div class="text-sm text-end">
           <%= link_to new_password_path(resource_name) do %>
             <span class="font-semibold text-indigo-600 hover:text-indigo-500">
-              Forgot password?
+              <%= t('devise.sessions.new.forgot') %>
             </span>
           <% end %>
         </div>
 
         <div>
-          <%= f.button :submit, "Log in", class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
+          <%= f.button :submit, t('devise.sessions.new.login'), class: "flex w-full justify-center rounded-md bg-indigo-600 px-3 py-1.5 text-sm font-semibold leading-6 text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600" %>
         </div>
       </div>
     <% end %>
     <p class="mt-10 text-center text-sm text-gray-500">
-      Not a member?
+      <%= t('devise.sessions.new.not_a_member') %>
       <%= link_to new_registration_path(resource_name) do %>
         <span class="font-semibold leading-6 text-indigo-600 hover:text-indigo-500">
-          Sign up
+          <%= t('devise.sessions.new.signup') %>
         </span>
       <% end %>
     </p>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to t('devise.sessions.new.login'), new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to t('devise.registrations.new.signup'), new_registration_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
+  <%= link_to t('devise.passwords.forgot'), new_password_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <%= link_to t('devise.confirmations.missing'), new_confirmation_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <%= link_to t('devise.unlocks.missing'), new_unlock_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
+    <%= button_to t('devise.omniauth.sign_in_with', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), data: { turbo: false } %><br />
   <% end %>
 <% end %>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -10,8 +10,8 @@
     </div>
     <div class="hidden md:flex flex-1 mx-8">
       <%= form_with url: dashboard_blog_posts_path, method: :get, local: true, class: "flex w-full" do |f| %>
-        <%= f.text_field :q, value: params[:q], placeholder: "Search", class: "flex-1 border rounded-l-full px-4 py-1" %>
-        <%= f.submit "Search", class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>
+        <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1" %>
+        <%= f.submit t('nav.search'), class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>
       <% end %>
     </div>
     <div class="hidden md:flex items-center space-x-4">
@@ -22,17 +22,17 @@
           </svg>
         <% end %>
         <%= link_to user_path(current_user), class: "text-gray-700 hover:text-gray-900" do %>
-          Profile
+          <%= t('nav.profile') %>
         <% end %>
         <%= button_to destroy_user_session_path, method: :delete, class: "text-gray-700 hover:text-gray-900" do %>
-          Log out
+          <%= t('nav.logout') %>
         <% end %>
       <% else %>
         <%= link_to user_session_path, class: "text-gray-700 hover:text-gray-900" do %>
-          Login
+          <%= t('nav.login') %>
         <% end %>
         <%= link_to new_user_registration_path, class: "text-gray-700 hover:text-gray-900" do %>
-          Signup
+          <%= t('nav.signup') %>
         <% end %>
       <% end %>
     </div>
@@ -47,16 +47,16 @@
   <div class="mobile-menu hidden md:hidden" data-mobile-menu-target="menu">
     <div class="px-4 pb-4 space-y-2">
       <%= form_with url: dashboard_blog_posts_path, method: :get, local: true, class: "flex space-x-2" do |f| %>
-        <%= f.text_field :q, value: params[:q], placeholder: "Search", class: "flex-1 border rounded-l-full px-4 py-1" %>
-        <%= f.submit "Search", class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>
+        <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1" %>
+        <%= f.submit t('nav.search'), class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>
       <% end %>
       <% if user_signed_in? %>
-        <%= link_to new_blog_post_path, class: "block py-2" do %>Upload<% end %>
-        <%= link_to user_path(current_user), class: "block py-2" do %>Profile<% end %>
-        <%= button_to destroy_user_session_path, method: :delete, class: "block py-2 text-left" do %>Log out<% end %>
+        <%= link_to new_blog_post_path, class: "block py-2" do %><%= t('nav.upload') %><% end %>
+        <%= link_to user_path(current_user), class: "block py-2" do %><%= t('nav.profile') %><% end %>
+        <%= button_to destroy_user_session_path, method: :delete, class: "block py-2 text-left" do %><%= t('nav.logout') %><% end %>
       <% else %>
-        <%= link_to user_session_path, class: "block py-2" do %>Login<% end %>
-        <%= link_to new_user_registration_path, class: "block py-2" do %>Signup<% end %>
+        <%= link_to user_session_path, class: "block py-2" do %><%= t('nav.login') %><% end %>
+        <%= link_to new_user_registration_path, class: "block py-2" do %><%= t('nav.signup') %><% end %>
       <% end %>
     </div>
   </div>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -35,6 +35,12 @@
           <%= t('nav.signup') %>
         <% end %>
       <% end %>
+      <%= form_with url: language_path, method: :patch, local: true do %>
+        <%= select_tag :locale,
+                        options_for_select([[t('language.english'), 'en'], [t('language.chinese'), 'zh']], I18n.locale),
+                        onchange: 'this.form.submit();',
+                        class: 'border rounded px-1 py-0.5 text-sm' %>
+      <% end %>
     </div>
     <div class="md:hidden flex items-center">
       <button class="mobile-menu-button" data-action="click->mobile-menu#toggleMenu">
@@ -57,6 +63,12 @@
       <% else %>
         <%= link_to user_session_path, class: "block py-2" do %><%= t('nav.login') %><% end %>
         <%= link_to new_user_registration_path, class: "block py-2" do %><%= t('nav.signup') %><% end %>
+      <% end %>
+      <%= form_with url: language_path, method: :patch, local: true do %>
+        <%= select_tag :locale,
+                        options_for_select([[t('language.english'), 'en'], [t('language.chinese'), 'zh']], I18n.locale),
+                        onchange: 'this.form.submit();',
+                        class: 'border rounded px-1 py-0.5 text-sm w-full' %>
       <% end %>
     </div>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -5,14 +5,14 @@
       <p class="mt-2 text-lg leading-8 text-gray-600"><%= @user.email %></p>
       <% if user_signed_in? && current_user == @user %>
         <div class="mt-4">
-          <%= link_to 'Edit profile', edit_user_registration_path,
+          <%= link_to t('users.edit_profile'), edit_user_registration_path,
                       class: 'inline-flex items-center rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600' %>
         </div>
       <% end %>
     </div>
 
     <div class="mt-12">
-      <h2 class="text-2xl font-bold tracking-tight text-gray-900 mb-6">Blog Posts</h2>
+      <h2 class="text-2xl font-bold tracking-tight text-gray-900 mb-6"><%= t('users.blog_posts') %></h2>
       <div class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
         <% @blog_posts.each do |blog| %>
           <div class="rounded-lg bg-gray-50 p-4 shadow">

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,5 +25,7 @@ module TibMarketplace
     # config.eager_load_paths << Rails.root.join("extras")
     config.assets.enabled = true
 
+    config.i18n.available_locales = %i[en zh]
+    config.i18n.default_locale = :en
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,3 +29,67 @@
 
 en:
   hello: "Hello world"
+  nav:
+    search: "Search"
+    profile: "Profile"
+    logout: "Log out"
+    login: "Login"
+    signup: "Signup"
+    upload: "Upload"
+  posts:
+    upload_your_video: "Upload Your Video"
+    edit_video: "Edit Video"
+    title: "Title"
+    enter_title: "Enter video title..."
+    description: "Description"
+    enter_description: "Write a brief description..."
+    choose_video: "Choose Video"
+    publish_at: "Publish At"
+    upload_video: "Upload Video"
+    update_video: "Update Video"
+    new_blog: "New Blog"
+    edit: "Edit"
+    uploaded_at: "Uploaded at"
+    author: "Author"
+    sign_in_prompt_html: "Please %{link} to add a comment."
+  comments:
+    add: "Add a comment"
+    placeholder: "Write your comment..."
+    post: "Post Comment"
+    reply: "Reply"
+  language:
+    label: "Language"
+    english: "English"
+    chinese: "Chinese"
+  common:
+    delete: "Delete"
+    are_you_sure: "Are you sure?"
+    cancel: "Cancel"
+    back: "Back"
+  users:
+    edit_profile: "Edit profile"
+    blog_posts: "Blog Posts"
+  devise:
+    sessions:
+      new:
+        login: "Log in"
+        forgot: "Forgot password?"
+        not_a_member: "Not a member?"
+        signup: "Sign up"
+    registrations:
+      new:
+        signup: "Sign up"
+        have_account: "Already have an account?"
+        login: "Login"
+      edit:
+        title: "Edit %{model}"
+        update: "Update"
+        cancel: "Cancel my account"
+    passwords:
+      forgot: "Forgot your password?"
+    confirmations:
+      missing: "Didn't receive confirmation instructions?"
+    unlocks:
+      missing: "Didn't receive unlock instructions?"
+    omniauth:
+      sign_in_with: "Sign in with %{provider}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,3 +93,7 @@ en:
       missing: "Didn't receive unlock instructions?"
     omniauth:
       sign_in_with: "Sign in with %{provider}"
+
+  time:
+    formats:
+      short: "%b %d, %Y %H:%M"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -1,0 +1,65 @@
+zh:
+  nav:
+    search: "\u641C\u7D22"
+    profile: "\u4E2A\u4EBA\u8D44\u6599"
+    logout: "\u9000\u51FA\u767B\u5F55"
+    login: "\u767B\u5F55"
+    signup: "\u6CE8\u518C"
+    upload: "\u4E0A\u4F20"
+  posts:
+    upload_your_video: "\u4E0A\u4F20\u60A8\u7684\u89C6\u9891"
+    edit_video: "\u7F16\u8F91\u89C6\u9891"
+    title: "\u6807\u9898"
+    enter_title: "\u8F93\u5165\u89C6\u9891\u6807\u9898..."
+    description: "\u63CF\u8FF0"
+    enter_description: "\u8BF4\u660E\u7B80\u4ECB..."
+    choose_video: "\u9009\u62E9\u89C6\u9891"
+    publish_at: "\u53D1\u5E03\u65F6\u95F4"
+    upload_video: "\u4E0A\u4F20\u89C6\u9891"
+    update_video: "\u66F4\u65B0\u89C6\u9891"
+    new_blog: "\u65B0\u5E16\u5B50"
+    edit: "\u7F16\u8F91"
+    uploaded_at: "\u4E0A\u4F20\u4E8E"
+    author: "\u4F5C\u8005"
+    sign_in_prompt_html: "\u8BF7%{link}\u53D1\u8868\u8BC4\u8BBA\u3002"
+  comments:
+    add: "\u65B0\u589E\u8BC4\u8BBA"
+    placeholder: "\u8F93\u5165\u60A8\u7684\u8BC4\u8BBA..."
+    post: "\u53D1\u8868\u8BC4\u8BBA"
+    reply: "\u56DE\u590D"
+  language:
+    label: "\u8BED\u8A00"
+    english: "\u82F1\u8BED"
+    chinese: "\u4E2D\u6587"
+  common:
+    delete: "\u5220\u9664"
+    are_you_sure: "\u786E\u8BA4\u5220\u9664?"
+    cancel: "\u53D6\u6D88"
+    back: "\u8FD4\u56DE"
+  users:
+    edit_profile: "\u7F16\u8F91\u4E2A\u4EBA\u4FE1\u606F"
+    blog_posts: "\u535A\u6587"
+  devise:
+    sessions:
+      new:
+        login: "\u767B\u5F55"
+        forgot: "\u5FD8\u8BB0\u5BC6\u7801?"
+        not_a_member: "\u8FD8\u6CA1\u6709\u8D26\u53F7?"
+        signup: "\u6CE8\u518C"
+    registrations:
+      new:
+        signup: "\u6CE8\u518C"
+        have_account: "\u5DF2\u7ECF\u6709\u8D26\u53F7?"
+        login: "\u767B\u5F55"
+      edit:
+        title: "\u7F16\u8F91%{model}"
+        update: "\u66F4\u65B0"
+        cancel: "\u5220\u9664\u6211\u7684\u8D26\u53F7"
+    passwords:
+      forgot: "\u5FD8\u8BB0\u5BC6\u7801?"
+    confirmations:
+      missing: "\u672A\u6536\u5230\u786E\u8BA4\u90AE\u4EF6?"
+    unlocks:
+      missing: "\u672A\u6536\u5230\u89E3\u9501\u90AE\u4EF6?"
+    omniauth:
+      sign_in_with: "\u4F7F\u7528%{provider}\u767B\u5F55"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -61,5 +61,9 @@ zh:
       missing: "\u672A\u6536\u5230\u786E\u8BA4\u90AE\u4EF6?"
     unlocks:
       missing: "\u672A\u6536\u5230\u89E3\u9501\u90AE\u4EF6?"
-    omniauth:
+  omniauth:
       sign_in_with: "\u4F7F\u7528%{provider}\u767B\u5F55"
+
+  time:
+    formats:
+      short: "%Y\u5E74%m\u6708%d\u65E5 %H:%M"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,5 +12,6 @@ Rails.application.routes.draw do
     end
   end
   resources :comments, only: [:create, :destroy]
+  resource :language, only: [:update]
   root "blog_posts#dashboard"
 end

--- a/db/migrate/20250704140000_add_language_to_users.rb
+++ b/db/migrate/20250704140000_add_language_to_users.rb
@@ -1,0 +1,5 @@
+class AddLanguageToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :language, :string, default: 'en'
+  end
+end


### PR DESCRIPTION
## Summary
- allow users to choose a language on the profile page
- set locale from user preference
- translate navigation, posts, comments and devise pages
- provide English and Chinese locale files
- add migration for language column on users

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cea3809408322b2fe8febca00b9cd