### PR TITLE
Add dark mode support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "bootsnap", require: false
 gem "image_processing", "~> 1.2"
 
 gem 'simple_form'
-gem "tailwindcss-rails", "~> 2.4"
+gem "tailwindcss-rails", "~> 2.7"
 gem "devise", "~> 4.9"
 gem  "aws-sdk-s3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,17 +260,17 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
-    tailwindcss-rails (2.4.0)
+    tailwindcss-rails (2.7.0)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-aarch64-linux)
+    tailwindcss-rails (2.7.0-aarch64-linux)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-arm-linux)
+    tailwindcss-rails (2.7.0-arm-linux)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-arm64-darwin)
+    tailwindcss-rails (2.7.0-arm64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-x86_64-darwin)
+    tailwindcss-rails (2.7.0-x86_64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-x86_64-linux)
+    tailwindcss-rails (2.7.0-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -321,7 +321,7 @@ DEPENDENCIES
   simple_form
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails (~> 2.4)
+  tailwindcss-rails (~> 2.7)
   turbo-rails
   tzinfo-data
   web-console

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.loadTheme()
+  }
+
+  toggle() {
+    if (document.documentElement.classList.contains('dark')) {
+      this.setTheme('light')
+    } else {
+      this.setTheme('dark')
+    }
+  }
+
+  loadTheme() {
+    const stored = localStorage.getItem('theme')
+    if (stored === 'dark' || (!stored && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      this.setTheme('dark', false)
+    } else {
+      this.setTheme('light', false)
+    }
+  }
+
+  setTheme(theme, store = true) {
+    document.documentElement.classList.toggle('dark', theme === 'dark')
+    if (store) {
+      localStorage.setItem('theme', theme)
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-controller="theme">
   <head>
     <title>BloPo</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -11,7 +11,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="flex flex-col min-h-screen">
+  <body class="flex flex-col min-h-screen bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100">
     <%= render "shared/nav_bar"%>
 
     <% if notice %>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-white border-b shadow-sm" data-controller="mobile-menu">
+<nav class="bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700 shadow-sm" data-controller="mobile-menu">
   <div class="mx-auto max-w-7xl px-4 py-2 flex items-center justify-between">
     <div class="flex items-center space-x-2">
       <%= link_to dashboard_blog_posts_path, class: "flex items-center" do %>
@@ -10,28 +10,28 @@
     </div>
     <div class="hidden md:flex flex-1 mx-8">
       <%= form_with url: dashboard_blog_posts_path, method: :get, local: true, class: "flex w-full" do |f| %>
-        <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1" %>
+        <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1 dark:bg-gray-700 dark:text-white" %>
         <%= f.submit t('nav.search'), class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>
       <% end %>
     </div>
     <div class="hidden md:flex items-center space-x-4">
       <% if user_signed_in? %>
-        <%= link_to new_blog_post_path, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to new_blog_post_path, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300" do %>
           <svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
           </svg>
         <% end %>
-        <%= link_to user_path(current_user), class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to user_path(current_user), class: "text-gray-700 hover:text-gray-900 dark:text-gray-300" do %>
           <%= t('nav.profile') %>
         <% end %>
-        <%= button_to destroy_user_session_path, method: :delete, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= button_to destroy_user_session_path, method: :delete, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300" do %>
           <%= t('nav.logout') %>
         <% end %>
       <% else %>
-        <%= link_to user_session_path, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to user_session_path, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300" do %>
           <%= t('nav.login') %>
         <% end %>
-        <%= link_to new_user_registration_path, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to new_user_registration_path, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300" do %>
           <%= t('nav.signup') %>
         <% end %>
       <% end %>
@@ -39,8 +39,9 @@
         <%= select_tag :locale,
                         options_for_select([[t('language.english'), 'en'], [t('language.chinese'), 'zh']], I18n.locale),
                         onchange: 'this.form.submit();',
-                        class: 'border rounded px-1 py-0.5 text-sm' %>
+                        class: 'border rounded px-1 py-0.5 text-sm dark:bg-gray-700 dark:text-white' %>
       <% end %>
+      <button data-action="theme#toggle" class="px-2 py-1 text-gray-700 hover:text-gray-900 dark:text-gray-300">🌓</button>
     </div>
     <div class="md:hidden flex items-center">
       <button class="mobile-menu-button" data-action="click->mobile-menu#toggleMenu">
@@ -53,7 +54,7 @@
   <div class="mobile-menu hidden md:hidden" data-mobile-menu-target="menu">
     <div class="px-4 pb-4 space-y-2">
       <%= form_with url: dashboard_blog_posts_path, method: :get, local: true, class: "flex space-x-2" do |f| %>
-        <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1" %>
+        <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1 dark:bg-gray-700 dark:text-white" %>
         <%= f.submit t('nav.search'), class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>
       <% end %>
       <% if user_signed_in? %>
@@ -68,8 +69,9 @@
         <%= select_tag :locale,
                         options_for_select([[t('language.english'), 'en'], [t('language.chinese'), 'zh']], I18n.locale),
                         onchange: 'this.form.submit();',
-                        class: 'border rounded px-1 py-0.5 text-sm w-full' %>
+                        class: 'border rounded px-1 py-0.5 text-sm w-full dark:bg-gray-700 dark:text-white' %>
       <% end %>
+      <button data-action="theme#toggle" class="px-2 py-1 text-gray-700 hover:text-gray-900 dark:text-gray-300">🌓</button>
     </div>
   </div>
 </nav>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     './app/javascript/**/*.js',
     './app/views/**/*.{erb,haml,html,slim}'
   ],
+  darkMode: 'class',
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Summary
- upgrade Tailwind gem reference
- enable `darkMode: 'class'` in Tailwind config
- add theme controller for toggling light/dark mode
- style layouts and nav bar for dark mode
- expose a toggle button in the navigation

## Testing
- `bundle install` *(fails: ruby version and network)*
- `bundle exec rake test` *(fails: RubyVersionMismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686cf09def7083229770658f522e4945