### PR TITLE
Add dark mode toggle and upgrade Tailwind

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "bootsnap", require: false
 gem "image_processing", "~> 1.2"
 
 gem 'simple_form'
-gem "tailwindcss-rails", "~> 2.4"
+gem "tailwindcss-rails", "~> 2.5"
 gem "devise", "~> 4.9"
 gem  "aws-sdk-s3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,17 +260,17 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
-    tailwindcss-rails (2.4.0)
+    tailwindcss-rails (2.5.0)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-aarch64-linux)
+    tailwindcss-rails (2.5.0-aarch64-linux)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-arm-linux)
+    tailwindcss-rails (2.5.0-arm-linux)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-arm64-darwin)
+    tailwindcss-rails (2.5.0-arm64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-x86_64-darwin)
+    tailwindcss-rails (2.5.0-x86_64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-x86_64-linux)
+    tailwindcss-rails (2.5.0-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -321,7 +321,7 @@ DEPENDENCIES
   simple_form
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails (~> 2.4)
+  tailwindcss-rails (~> 2.5)
   turbo-rails
   tzinfo-data
   web-console

--- a/app/javascript/controllers/dark_mode_controller.js
+++ b/app/javascript/controllers/dark_mode_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.applyTheme()
+  }
+
+  toggle() {
+    const current = localStorage.getItem('theme')
+    if (current === 'dark') {
+      localStorage.setItem('theme', 'light')
+    } else {
+      localStorage.setItem('theme', 'dark')
+    }
+    this.applyTheme()
+  }
+
+  applyTheme() {
+    const theme = localStorage.getItem('theme')
+    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+    if (theme === 'dark' || (!theme && prefersDark)) {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="flex flex-col min-h-screen">
+  <body class="flex flex-col min-h-screen bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100" data-controller="dark-mode">
     <%= render "shared/nav_bar"%>
 
     <% if notice %>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-white border-b shadow-sm" data-controller="mobile-menu">
+<nav class="bg-white dark:bg-gray-800 border-b shadow-sm" data-controller="mobile-menu">
   <div class="mx-auto max-w-7xl px-4 py-2 flex items-center justify-between">
     <div class="flex items-center space-x-2">
       <%= link_to dashboard_blog_posts_path, class: "flex items-center" do %>
@@ -16,22 +16,22 @@
     </div>
     <div class="hidden md:flex items-center space-x-4">
       <% if user_signed_in? %>
-        <%= link_to new_blog_post_path, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to new_blog_post_path, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" do %>
           <svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path d="M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z" />
           </svg>
         <% end %>
-        <%= link_to user_path(current_user), class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to user_path(current_user), class: "text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" do %>
           <%= t('nav.profile') %>
         <% end %>
-        <%= button_to destroy_user_session_path, method: :delete, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= button_to destroy_user_session_path, method: :delete, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" do %>
           <%= t('nav.logout') %>
         <% end %>
       <% else %>
-        <%= link_to user_session_path, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to user_session_path, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" do %>
           <%= t('nav.login') %>
         <% end %>
-        <%= link_to new_user_registration_path, class: "text-gray-700 hover:text-gray-900" do %>
+        <%= link_to new_user_registration_path, class: "text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white" do %>
           <%= t('nav.signup') %>
         <% end %>
       <% end %>
@@ -41,6 +41,9 @@
                         onchange: 'this.form.submit();',
                         class: 'border rounded px-1 py-0.5 text-sm' %>
       <% end %>
+      <button data-action="click->dark-mode#toggle" class="text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+        <%= t('nav.dark_mode') %>
+      </button>
     </div>
     <div class="md:hidden flex items-center">
       <button class="mobile-menu-button" data-action="click->mobile-menu#toggleMenu">
@@ -70,6 +73,9 @@
                         onchange: 'this.form.submit();',
                         class: 'border rounded px-1 py-0.5 text-sm w-full' %>
       <% end %>
+      <button data-action="click->dark-mode#toggle" class="block py-2 text-left w-full text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-white">
+        <%= t('nav.dark_mode') %>
+      </button>
     </div>
   </div>
 </nav>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -36,6 +36,7 @@ en:
     login: "Login"
     signup: "Signup"
     upload: "Upload"
+    dark_mode: "Toggle Dark Mode"
   posts:
     upload_your_video: "Upload Your Video"
     edit_video: "Edit Video"

--- a/config/locales/zh.yml
+++ b/config/locales/zh.yml
@@ -6,6 +6,7 @@ zh:
     login: "\u767B\u5F55"
     signup: "\u6CE8\u518C"
     upload: "\u4E0A\u4F20"
+    dark_mode: "\u5207\u6362\u6697\u9ED1\u6A21\u5F0F"
   posts:
     upload_your_video: "\u4E0A\u4F20\u60A8\u7684\u89C6\u9891"
     edit_video: "\u7F16\u8F91\u89C6\u9891"

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './public/*.html',
     './app/helpers/**/*.rb',


### PR DESCRIPTION
## Summary
- bump `tailwindcss-rails` version
- enable class-based dark mode in Tailwind config
- add Stimulus controller to toggle dark/light theme
- hook up dark mode button in the navigation
- style layout and navigation for dark mode
- update translations

## Testing
- `bin/rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cf09def7083229770658f522e4945