### PR TITLE
Add dark mode toggle and update Tailwind

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem "bootsnap", require: false
 gem "image_processing", "~> 1.2"
 
 gem 'simple_form'
-gem "tailwindcss-rails", "~> 2.4"
+gem "tailwindcss-rails", "~> 2.6"
 gem "devise", "~> 4.9"
 gem  "aws-sdk-s3", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -260,17 +260,17 @@ GEM
     stimulus-rails (1.3.3)
       railties (>= 6.0.0)
     stringio (3.1.0)
-    tailwindcss-rails (2.4.0)
+    tailwindcss-rails (2.6.0)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-aarch64-linux)
+    tailwindcss-rails (2.6.0-aarch64-linux)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-arm-linux)
+    tailwindcss-rails (2.6.0-arm-linux)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-arm64-darwin)
+    tailwindcss-rails (2.6.0-arm64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-x86_64-darwin)
+    tailwindcss-rails (2.6.0-x86_64-darwin)
       railties (>= 6.0.0)
-    tailwindcss-rails (2.4.0-x86_64-linux)
+    tailwindcss-rails (2.6.0-x86_64-linux)
       railties (>= 6.0.0)
     thor (1.3.1)
     timeout (0.4.1)
@@ -321,7 +321,7 @@ DEPENDENCIES
   simple_form
   sprockets-rails
   stimulus-rails
-  tailwindcss-rails (~> 2.4)
+  tailwindcss-rails (~> 2.6)
   turbo-rails
   tzinfo-data
   web-console

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["sun", "moon"]
+
+  connect() {
+    this.loadTheme()
+  }
+
+  toggle() {
+    if (document.documentElement.classList.contains('dark')) {
+      this.setLight()
+    } else {
+      this.setDark()
+    }
+  }
+
+  loadTheme() {
+    const theme = localStorage.getItem('theme')
+    if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      this.setDark(false)
+    } else {
+      this.setLight(false)
+    }
+  }
+
+  setDark(save = true) {
+    document.documentElement.classList.add('dark')
+    this.sunTarget.classList.add('hidden')
+    this.moonTarget.classList.remove('hidden')
+    if (save) localStorage.setItem('theme', 'dark')
+  }
+
+  setLight(save = true) {
+    document.documentElement.classList.remove('dark')
+    this.sunTarget.classList.remove('hidden')
+    this.moonTarget.classList.add('hidden')
+    if (save) localStorage.setItem('theme', 'light')
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,7 +11,7 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="flex flex-col min-h-screen">
+  <body class="flex flex-col min-h-screen bg-white dark:bg-gray-900 dark:text-gray-100" data-controller="theme">
     <%= render "shared/nav_bar"%>
 
     <% if notice %>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-white border-b shadow-sm" data-controller="mobile-menu">
+<nav class="bg-white dark:bg-gray-800 dark:text-gray-100 border-b shadow-sm" data-controller="mobile-menu">
   <div class="mx-auto max-w-7xl px-4 py-2 flex items-center justify-between">
     <div class="flex items-center space-x-2">
       <%= link_to dashboard_blog_posts_path, class: "flex items-center" do %>
@@ -41,6 +41,15 @@
                         onchange: 'this.form.submit();',
                         class: 'border rounded px-1 py-0.5 text-sm' %>
       <% end %>
+      <button data-action="theme#toggle" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700">
+        <svg data-theme-target="sun" class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <circle cx="12" cy="12" r="5" />
+          <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+        </svg>
+        <svg data-theme-target="moon" class="h-6 w-6 hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+        </svg>
+      </button>
     </div>
     <div class="md:hidden flex items-center">
       <button class="mobile-menu-button" data-action="click->mobile-menu#toggleMenu">
@@ -70,6 +79,18 @@
                         onchange: 'this.form.submit();',
                         class: 'border rounded px-1 py-0.5 text-sm w-full' %>
       <% end %>
+      <button data-action="theme#toggle" class="p-1 rounded hover:bg-gray-200 dark:hover:bg-gray-700 w-full text-left">
+        <span class="inline-flex items-center">
+          <svg data-theme-target="sun" class="h-6 w-6" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <circle cx="12" cy="12" r="5" />
+            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+          </svg>
+          <svg data-theme-target="moon" class="h-6 w-6 hidden" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+          </svg>
+          <span class="ml-2"><%= t('nav.toggle_theme', default: 'Toggle Theme') %></span>
+        </span>
+      </button>
     </div>
   </div>
 </nav>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './public/*.html',
     './app/helpers/**/*.rb',


### PR DESCRIPTION
## Summary
- bump `tailwindcss-rails` gem to 2.6
- enable `darkMode` in tailwind config
- add a stimulus `theme_controller` to persist theme selection
- integrate dark mode classes and toggle buttons in the navbar
- hook theme controller from the application layout

## Testing
- `bundle exec rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686cf09def7083229770658f522e4945