### PR TITLE
Add streaming UI with Tailwind and Stimulus

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply bg-white text-gray-800 dark:bg-gray-900 dark:text-gray-100;
+  }
+  nav {
+    @apply dark:bg-gray-800;
+  }
+}
+
 /*
 
 @layer components {

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,7 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  toggle() {
+    document.documentElement.classList.toggle('dark')
+  }
+}

--- a/app/javascript/controllers/video_modal_controller.js
+++ b/app/javascript/controllers/video_modal_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["modal", "video"]
+
+  open(event) {
+    const url = event.currentTarget.dataset.url
+    if (url) {
+      this.videoTarget.src = url
+    }
+    this.modalTarget.classList.remove('hidden')
+  }
+
+  close() {
+    this.modalTarget.classList.add('hidden')
+    this.videoTarget.pause()
+  }
+}

--- a/app/views/blog_posts/dashboard.html.erb
+++ b/app/views/blog_posts/dashboard.html.erb
@@ -1,7 +1,12 @@
-<div class="mx-auto max-w-7xl px-4 py-6">
+<div class="mx-auto max-w-7xl px-4 py-6" data-controller="video-modal">
+  <div class="mb-6 flex gap-2 overflow-x-auto">
+    <span class="px-4 py-1 rounded-full bg-white shadow text-sm">All</span>
+    <span class="px-4 py-1 rounded-full bg-white shadow text-sm">Latest</span>
+    <span class="px-4 py-1 rounded-full bg-white shadow text-sm">Popular</span>
+  </div>
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
     <% @blog_posts.each do |blog| %>
-      <div class="bg-white rounded-lg shadow overflow-hidden">
+      <div class="bg-white rounded-lg shadow overflow-hidden cursor-pointer" data-action="click->video-modal#open" data-url="<%= url_for(blog.video) if blog.video.attached? %>">
         <div class="aspect-video bg-black">
           <% if blog.video.attached? %>
             <%= video_tag blog.video, controls: false, preload: :metadata, class: "w-full h-full object-cover" %>
@@ -21,5 +26,12 @@
   </div>
   <div class="my-8 flex justify-center">
     <%== pagy_nav(@pagy) if @pagy.pages > 1 %>
+  </div>
+</div>
+
+<div data-video-modal-target="modal" class="fixed inset-0 bg-black/80 flex items-center justify-center hidden">
+  <div class="bg-white p-4 rounded-lg w-full max-w-3xl">
+    <button data-action="click->video-modal#close" class="text-gray-700 mb-2">&times;</button>
+    <video data-video-modal-target="video" controls class="w-full"></video>
   </div>
 </div>

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-white border-b shadow-sm" data-controller="mobile-menu">
+<nav class="bg-gradient-to-r from-purple-600 via-pink-500 to-indigo-500 text-white" data-controller="mobile-menu">
   <div class="mx-auto max-w-7xl px-4 py-2 flex items-center justify-between">
     <div class="flex items-center space-x-2">
       <%= link_to dashboard_blog_posts_path, class: "flex items-center" do %>
@@ -15,6 +15,11 @@
       <% end %>
     </div>
     <div class="hidden md:flex items-center space-x-4">
+      <button class="p-2" data-controller="theme" data-action="click->theme#toggle">
+        <svg class="h-6 w-6" viewBox="0 0 24 24" fill="currentColor">
+          <path d="M12 3a1 1 0 011 1v1a1 1 0 11-2 0V4a1 1 0 011-1zm5.657 2.343a1 1 0 010 1.414l-.707.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM18 11a1 1 0 100 2h1a1 1 0 100-2h-1zM6 11a1 1 0 100 2H5a1 1 0 100-2h1zm-.343-5.657a1 1 0 011.414 0l.707.707A1 1 0 016.364 7.464l-.707-.707a1 1 0 010-1.414zM12 18a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zm6.364-2.536a1 1 0 00-1.414 1.414l.707.707a1 1 0 001.414-1.414l-.707-.707zM6.343 17.657a1 1 0 00-1.414-1.414l-.707.707a1 1 0 101.414 1.414l.707-.707z" />
+        </svg>
+      </button>
       <% if user_signed_in? %>
         <%= link_to new_blog_post_path, class: "text-gray-700 hover:text-gray-900" do %>
           <svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './public/*.html',
     './app/helpers/**/*.rb',


### PR DESCRIPTION
## Summary
- enable dark mode support in Tailwind
- style base elements for dark theme
- add theme toggle Stimulus controller
- add video modal Stimulus controller
- update navigation bar with gradient colors and theme toggle button
- enhance dashboard with filter chips and modal playback

## Testing
- `bundle exec rails test` *(fails: ruby-3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871303ac8fc83229cb2ec14e6476934