### PR TITLE
Add dark mode theme toggle using Stimulus

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,6 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
+@layer base {
+  body {
+    @apply bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+  }
+
+  nav {
+    @apply bg-gradient-to-r from-purple-600 to-pink-500 text-white dark:from-gray-800 dark:to-gray-700;
+  }
+}
+
 /*
 
 @layer components {

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,32 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["icon"]
+
+  connect() {
+    this.dark = (localStorage.getItem("theme") === "dark")
+    if (this.dark) {
+      document.documentElement.classList.add("dark")
+    }
+    this.updateIcon()
+  }
+
+  toggle() {
+    this.dark = !this.dark
+    document.documentElement.classList.toggle("dark", this.dark)
+    localStorage.setItem("theme", this.dark ? "dark" : "light")
+    this.updateIcon()
+  }
+
+  updateIcon() {
+    this.iconTarget.innerHTML = this.dark ? this.sunIcon() : this.moonIcon()
+  }
+
+  sunIcon() {
+    return `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 3.5a.75.75 0 01.75-.75h.5a.75.75 0 010 1.5h-.5A.75.75 0 0110 3.5zM10 15.75a.75.75 0 01.75.75v.5a.75.75 0 01-1.5 0v-.5a.75.75 0 01.75-.75zM4.28 5.22a.75.75 0 011.06 0l.35.35a.75.75 0 11-1.06 1.06l-.35-.35a.75.75 0 010-1.06zM14.31 15.25a.75.75 0 011.06 0l.35.35a.75.75 0 11-1.06 1.06l-.35-.35a.75.75 0 010-1.06zM3.5 10a.75.75 0 01-.75-.75v-.5a.75.75 0 011.5 0v.5A.75.75 0 013.5 10zM16.25 10a.75.75 0 01-.75.75h-.5a.75.75 0 010-1.5h.5a.75.75 0 01.75.75zM5.22 14.28a.75.75 0 010 1.06l-.35.35a.75.75 0 11-1.06-1.06l.35-.35a.75.75 0 011.06 0zM15.25 4.31a.75.75 0 010 1.06l-.35.35a.75.75 0 11-1.06-1.06l.35-.35a.75.75 0 011.06 0zM10 6a4 4 0 100 8 4 4 0 000-8z"/></svg>`
+  }
+
+  moonIcon() {
+    return `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M17.293 13.293A8 8 0 116.707 2.707a6 6 0 0010.586 10.586z"/></svg>`
+  }
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,11 @@
     <%= stylesheet_link_tag "actiontext", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
+    <script>
+      if (localStorage.getItem('theme') === 'dark') {
+        document.documentElement.classList.add('dark')
+      }
+    </script>
   </head>
 
   <body class="flex flex-col min-h-screen">

--- a/app/views/shared/_nav_bar.html.erb
+++ b/app/views/shared/_nav_bar.html.erb
@@ -1,4 +1,4 @@
-<nav class="bg-white border-b shadow-sm" data-controller="mobile-menu">
+<nav class="border-b shadow-sm text-white" data-controller="mobile-menu theme">
   <div class="mx-auto max-w-7xl px-4 py-2 flex items-center justify-between">
     <div class="flex items-center space-x-2">
       <%= link_to dashboard_blog_posts_path, class: "flex items-center" do %>
@@ -15,6 +15,7 @@
       <% end %>
     </div>
     <div class="hidden md:flex items-center space-x-4">
+      <button class="p-2 rounded-full hover:bg-white/20" data-action="theme#toggle" data-theme-target="icon"></button>
       <% if user_signed_in? %>
         <%= link_to new_blog_post_path, class: "text-gray-700 hover:text-gray-900" do %>
           <svg class="h-6 w-6" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -52,6 +53,7 @@
   </div>
   <div class="mobile-menu hidden md:hidden" data-mobile-menu-target="menu">
     <div class="px-4 pb-4 space-y-2">
+      <button class="p-2 rounded-full hover:bg-white/20" data-action="theme#toggle" data-theme-target="icon"></button>
       <%= form_with url: dashboard_blog_posts_path, method: :get, local: true, class: "flex space-x-2" do |f| %>
         <%= f.text_field :q, value: params[:q], placeholder: t('nav.search'), class: "flex-1 border rounded-l-full px-4 py-1" %>
         <%= f.submit t('nav.search'), class: "px-4 py-1 bg-blue-500 text-white rounded-r-full" %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './public/*.html',
     './app/helpers/**/*.rb',


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- add base gradient styles and dark variants
- create `theme` Stimulus controller to switch themes
- embed theme toggle buttons in navigation bar (desktop and mobile)
- persist theme choice in `localStorage`

## Testing
- `bundle exec rails test` *(fails: ruby-3.3.0 is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871303ac8fc83229cb2ec14e6476934