### PR TITLE
Add StreamHub styling using Tailwind and Stimulus

### DIFF
--- a/app/javascript/controllers/streamhub_controller.js
+++ b/app/javascript/controllers/streamhub_controller.js
@@ -1,0 +1,40 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["sidebar", "modal"]
+
+  connect() {
+    // restore theme
+    if (localStorage.getItem('theme') === 'dark') {
+      document.documentElement.classList.add('dark')
+    }
+  }
+
+  toggleSidebar() {
+    this.sidebarTarget.classList.toggle('-translate-x-full')
+  }
+
+  toggleTheme() {
+    document.documentElement.classList.toggle('dark')
+    if (document.documentElement.classList.contains('dark')) {
+      localStorage.setItem('theme', 'dark')
+    } else {
+      localStorage.removeItem('theme')
+    }
+  }
+
+  openModal(event) {
+    const modalContent = event.currentTarget.dataset.video
+    if (modalContent && this.hasModalTarget) {
+      this.modalTarget.innerHTML = modalContent
+      this.modalTarget.classList.remove('hidden')
+    }
+  }
+
+  closeModal() {
+    if (this.hasModalTarget) {
+      this.modalTarget.classList.add('hidden')
+      this.modalTarget.innerHTML = ''
+    }
+  }
+}

--- a/app/views/blog_posts/dashboard.html.erb
+++ b/app/views/blog_posts/dashboard.html.erb
@@ -1,7 +1,7 @@
-<div class="mx-auto max-w-7xl px-4 py-6">
+<div class="pt-20 pl-0 md:pl-60 px-4">
   <div class="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
     <% @blog_posts.each do |blog| %>
-      <div class="bg-white rounded-lg shadow overflow-hidden">
+      <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden cursor-pointer" data-action="click->streamhub#openModal" data-video="<div class='space-y-4'><h2 class='text-xl font-bold'>#{blog.title}</h2><p class='text-sm text-gray-500'>#{blog.user.username}</p><div>#{j(blog.content.body.to_truncated_plain_text.tr('\n',' '))}</div></div>">
         <div class="aspect-video bg-black">
           <% if blog.video.attached? %>
             <%= video_tag blog.video, controls: false, preload: :metadata, class: "w-full h-full object-cover" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,8 +11,10 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="flex flex-col min-h-screen">
-    <%= render "shared/nav_bar"%>
+  <body class="flex min-h-screen bg-gray-50 dark:bg-gray-900" data-controller="streamhub">
+    <%= render "shared/streamhub/header" %>
+    <%= render "shared/streamhub/sidebar" %>
+    <%= render "shared/streamhub/modal" %>
 
     <% if notice %>
       <div class="flex justify-between py-4 px-8 bg-[#98f5e1]  text-[#236c5b]">

--- a/app/views/shared/streamhub/_header.html.erb
+++ b/app/views/shared/streamhub/_header.html.erb
@@ -1,0 +1,23 @@
+<header class="fixed top-0 left-0 right-0 h-16 bg-gradient-to-r from-purple-600 to-pink-500 text-white flex items-center px-4 z-50">
+  <div class="flex items-center space-x-3">
+    <button data-action="streamhub#toggleSidebar" class="p-2 rounded-lg bg-white/20 hover:bg-white/30">
+      <!-- menu icon -->
+      <svg class="h-6 w-6" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24" stroke-linecap="round" stroke-linejoin="round"><path d="M4 6h16M4 12h16M4 18h16"/></svg>
+    </button>
+    <div class="font-bold text-xl">StreamHub</div>
+  </div>
+  <div class="flex-1 mx-4 hidden md:block">
+    <div class="flex bg-white/20 rounded-full overflow-hidden">
+      <input type="text" placeholder="Search..." class="flex-1 bg-transparent px-4 py-2 placeholder-white text-white focus:outline-none"/>
+      <button class="px-4" >
+        <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+      </button>
+    </div>
+  </div>
+  <div class="flex items-center space-x-3">
+    <button data-action="streamhub#toggleTheme" class="p-2 rounded-lg bg-white/20 hover:bg-white/30">
+      <!-- moon icon -->
+      <svg class="h-6 w-6" fill="currentColor" viewBox="0 0 20 20"><path d="M10 2a8 8 0 106.32 12.906A9 9 0 0110 2z"/></svg>
+    </button>
+  </div>
+</header>

--- a/app/views/shared/streamhub/_modal.html.erb
+++ b/app/views/shared/streamhub/_modal.html.erb
@@ -1,0 +1,6 @@
+<div class="fixed inset-0 bg-black/80 flex items-center justify-center hidden" data-streamhub-target="modal">
+  <div class="bg-white dark:bg-gray-800 p-4 rounded-lg max-w-3xl w-full">
+    <button class="mb-2 text-gray-600 dark:text-gray-300" data-action="streamhub#closeModal">Close</button>
+    <div data-streamhub-target="modalContent"></div>
+  </div>
+</div>

--- a/app/views/shared/streamhub/_sidebar.html.erb
+++ b/app/views/shared/streamhub/_sidebar.html.erb
@@ -1,0 +1,13 @@
+<aside class="fixed top-16 left-0 w-60 h-[calc(100vh-4rem)] bg-white dark:bg-gray-800 border-r border-gray-200 dark:border-gray-700 transform transition-transform -translate-x-full md:translate-x-0" data-streamhub-target="sidebar">
+  <nav class="p-4 space-y-2">
+    <%= link_to '#', class: 'block px-3 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700' do %>
+      Home
+    <% end %>
+    <%= link_to '#', class: 'block px-3 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700' do %>
+      Popular
+    <% end %>
+    <%= link_to '#', class: 'block px-3 py-2 rounded hover:bg-gray-100 dark:hover:bg-gray-700' do %>
+      Following
+    <% end %>
+  </nav>
+</aside>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
+  darkMode: 'class',
   content: [
     './public/*.html',
     './app/helpers/**/*.rb',


### PR DESCRIPTION
## Summary
- apply StreamHub-style layout with gradient header and collapsible sidebar
- implement new Stimulus controller for sidebar, theme and modal actions
- enable dark mode support in Tailwind config
- update dashboard video cards to open modal via Stimulus

## Testing
- `bundle exec rails test` *(fails: ruby 3.3.0 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6871303ac8fc83229cb2ec14e6476934